### PR TITLE
Modifications for use in graph-node

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,7 @@ mod impls;
 pub mod prelude;
 mod sequence_number;
 mod stable_hash;
+pub mod utils;
 
 pub use crate::sequence_number::{SequenceNumber, SequenceNumberInt};
-pub use crate::stable_hash::{StableHash, StableHasher, StableHasherWrapper};
-
-/// Treat some &[u8] as a sequence of bytes, rather than a sequence of numbers.
-/// Using this can result in a significant performance gain but does not support
-/// the backward compatible change to different int types as numbers do by default
-pub struct AsBytes<'a>(pub &'a [u8]);
-
-impl StableHash for AsBytes<'_> {
-    fn stable_hash(&self, sequence_number: impl SequenceNumber, state: &mut impl StableHasher) {
-        if !self.0.is_empty() {
-            state.write(sequence_number, self.0)
-        }
-    }
-}
+pub use crate::stable_hash::{StableHash, StableHasher};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::{stable_hash::trim_zeros, AsBytes};
+pub(crate) use crate::utils::*;
 
 pub use crate::sequence_number::SequenceNumber;
 pub use crate::{StableHash, StableHasher};

--- a/src/sequence_number.rs
+++ b/src/sequence_number.rs
@@ -36,7 +36,7 @@ macro_rules! impl_sequence_no {
 
                 let rollup = (self.rollup * Wrapping($prime_mult)) + Wrapping(child as $T);
 
-                Self { rollup, child }
+                Self { rollup, child: 0 }
             }
 
             #[inline]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,73 @@
+use crate::prelude::*;
+use crate::SequenceNumberInt;
+use std::borrow::Borrow as _;
+use std::hash::Hasher;
+
+/// Treat some &[u8] as a sequence of bytes, rather than a sequence of numbers.
+/// Using this can result in a significant performance gain but does not support
+/// the backward compatible change to different int types as numbers do by default
+pub struct AsBytes<'a>(pub &'a [u8]);
+
+impl StableHash for AsBytes<'_> {
+    fn stable_hash(&self, sequence_number: impl SequenceNumber, state: &mut impl StableHasher) {
+        if !self.0.is_empty() {
+            state.write(sequence_number, self.0)
+        }
+    }
+}
+
+fn trim_zeros(bytes: &[u8]) -> &[u8] {
+    let mut end = bytes.len();
+    while end != 0 && bytes[end - 1] == 0 {
+        end -= 1;
+    }
+    &bytes[0..end]
+}
+
+/// Canonical way to write an integer of any size.
+///
+/// Backward compatibility:
+/// * The value +0 never writes bytes to the stream.
+/// * Integers of any size (u8..u24..u128...uN) are written in a canonical form, and can be written in any order.
+pub struct AsInt<'a> {
+    pub is_negative: bool,
+    pub little_endian: &'a [u8],
+}
+
+impl StableHash for AsInt<'_> {
+    fn stable_hash(&self, mut sequence_number: impl SequenceNumber, state: &mut impl StableHasher) {
+        self.is_negative
+            .stable_hash(sequence_number.next_child(), state);
+        let canon = trim_zeros(self.little_endian);
+        if !canon.is_empty() {
+            state.write(sequence_number, canon);
+        }
+    }
+}
+
+pub fn stable_hash<T: StableHasher, S: SequenceNumber, V: StableHash>(value: &V) -> T::Out {
+    let mut hasher = T::default();
+    value.stable_hash(S::root(), &mut hasher);
+    hasher.finish()
+}
+
+pub fn stable_hash_with_hasher<T: std::hash::Hasher + Default, V: StableHash>(value: &V) -> u64 {
+    stable_hash::<StableHasherWrapper<T>, SequenceNumberInt<u64>, _>(value)
+}
+
+/// Wraps a Hasher to implement StableHasher. It must be known that the Hasher behaves in
+/// a consistent manner regardless of platform or process.
+#[derive(Default)]
+struct StableHasherWrapper<T>(T);
+
+impl<T: Hasher + Default> StableHasher for StableHasherWrapper<T> {
+    type Out = u64;
+    fn write(&mut self, sequence_number: impl SequenceNumber, bytes: &[u8]) {
+        let seq_no = sequence_number.rollup();
+        self.0.write(seq_no.borrow());
+        self.0.write(bytes);
+    }
+    fn finish(&self) -> Self::Out {
+        self.0.finish()
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,9 +2,7 @@ use stable_hash::*;
 use twox_hash::XxHash64;
 
 pub fn xxhash(value: &impl StableHash) -> u64 {
-    let mut hasher = StableHasherWrapper::<XxHash64>::default();
-    value.stable_hash(SequenceNumberInt::<u64>::root(), &mut hasher);
-    hasher.finish()
+    utils::stable_hash_with_hasher::<XxHash64, _>(value)
 }
 
 #[macro_export]


### PR DESCRIPTION
I found some areas for improvement when putting this lib into use within graph-node. In particular, exposing the AsInt type so it could be re-used by BigInt and BigDecimal