### PR TITLE
Swapped dependency to hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,20 +177,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hex"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "stable-hash"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -225,6 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+"checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum leb128 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 "checksum libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
@@ -236,7 +237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 "checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-hash"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Zac Burns <That3Percent@gmail.com>"]
 edition = "2018"
 
@@ -14,4 +14,4 @@ lazy_static = "1.4.0"
 
 [dev-dependencies]
 twox-hash = "1.5.0"
-rustc-hex = "2.1.0"
+hex = "0.4.2"

--- a/src/crypto/blake3_sequence.rs
+++ b/src/crypto/blake3_sequence.rs
@@ -40,6 +40,21 @@ impl SequenceNumber for Blake3SeqNo {
 impl Blake3SeqNo {
     pub(crate) fn finish(self, payload: &[u8]) -> OutputReader {
         let Self { mut hasher, .. } = self;
+
+        // To debug all the payloads in a hash to find a diff, this can be useful.
+        /*
+        #[derive(Debug)]
+        struct Update {
+            payload: String,
+            seq_no: String,
+        }
+        let update = Update {
+            seq_no: hex::encode(hasher.finalize().as_bytes()),
+            payload: hex::encode(payload),
+        };
+        dbg!(update);
+        */
+
         // See also 91e48829-7bea-4426-971a-f092856269a5
         hasher.update(&[0]);
         hasher.update(payload);

--- a/tests/backward_compatibility.rs
+++ b/tests/backward_compatibility.rs
@@ -4,7 +4,6 @@ use stable_hash::utils::*;
 use std::hash::Hasher as _;
 use twox_hash::XxHash64;
 mod common;
-use rustc_hex::ToHex;
 
 struct One<T0> {
     one: T0,
@@ -59,29 +58,9 @@ fn add_non_default_field() {
 }
 
 #[test]
-fn next_child_calls_do_not_affect_output() {
-    struct S0;
-    impl StableHash for S0 {
-        fn stable_hash<H: StableHasher>(&self, sequence_number: H::Seq, state: &mut H) {
-            1u32.stable_hash(sequence_number, state);
-        }
-    }
-
-    struct S1;
-    impl StableHash for S1 {
-        fn stable_hash<H: StableHasher>(&self, mut sequence_number: H::Seq, state: &mut H) {
-            0u32.stable_hash(sequence_number.next_child(), state);
-            1u32.stable_hash(sequence_number, state);
-        }
-    }
-
-    equal!(4850997937794257732, "044100289e98a89ed394a64fec6960dbab147ca5b6560883c9ce5d65cd69bf51"; S0, S1);
-}
-
-#[test]
 fn defaults_are_non_emitting() {
     let empty_1 = XxHash64::default().finish();
-    let empty_2: String = SetHasher::default().finish().to_hex();
+    let empty_2: String = hex::encode(SetHasher::default().finish());
     equal!(empty_1, &empty_2; false, Option::<bool>::None, 0i32, Vec::<String>::new(), "");
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,3 @@
-use rustc_hex::ToHex;
 use stable_hash::crypto::SetHasher;
 use stable_hash::*;
 use twox_hash::XxHash64;
@@ -9,7 +8,7 @@ pub fn xxhash(value: &impl StableHash) -> u64 {
 
 pub fn crypto_hash(value: &impl StableHash) -> String {
     let raw = utils::stable_hash::<SetHasher, _>(value);
-    raw.to_hex()
+    hex::encode(raw)
 }
 
 #[macro_export]


### PR DESCRIPTION
This PR:

- Removes a misleading test case that inferred wrong information leading to poor implementations of `StableHash` (particularly for enums in graph-node) which would not allow backward-compatible additions. This also made it harder to reason about the online implementation.
- Swaps out the hex encoding dependency so that we have one fewer dependency in graph-node
- Adds a commented out payload debugging utility

Please also review: [Bugfix: Manufacturable collisions](https://github.com/graphprotocol/stable-hash/commit/38bfd456d626fab5922467405ebb50488714c6ab) which was pushed to master without review